### PR TITLE
Use multi_get for resolve and address statuses

### DIFF
--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -976,23 +976,3 @@ class SecondaryDB:
             self.logger.warning(f'all_utxos: tx hash not '
                                 f'found (reorg?), retrying...')
             await asyncio.sleep(0.25)
-
-    async def lookup_utxos(self, prevouts):
-        def lookup_utxos():
-            utxos = []
-            utxo_append = utxos.append
-            for (tx_hash, nout) in prevouts:
-                tx_num_val = self.prefix_db.tx_num.get(tx_hash)
-                if not tx_num_val:
-                    print("no tx num for ", tx_hash[::-1].hex())
-                    continue
-                tx_num = tx_num_val.tx_num
-                hashX_val = self.prefix_db.hashX_utxo.get(tx_hash[:4], tx_num, nout)
-                if not hashX_val:
-                    continue
-                hashX = hashX_val.hashX
-                utxo_value = self.prefix_db.utxo.get(hashX, tx_num, nout)
-                if utxo_value:
-                    utxo_append((hashX, utxo_value.amount))
-            return utxos
-        return await asyncio.get_event_loop().run_in_executor(self._executor, lookup_utxos)

--- a/hub/elastic_sync/db.py
+++ b/hub/elastic_sync/db.py
@@ -218,49 +218,5 @@ class ElasticSyncDB(SecondaryDB):
                 yield meta
         batch.clear()
 
-    def claim_producer(self, claim_hash: bytes) -> Optional[Dict]:
-        claim_txo = self.get_cached_claim_txo(claim_hash)
-        if not claim_txo:
-            self.logger.warning("can't sync non existent claim to ES: %s", claim_hash.hex())
-            return
-        if not self.prefix_db.claim_takeover.get(claim_txo.normalized_name):
-            self.logger.warning("can't sync non existent claim to ES: %s", claim_hash.hex())
-            return
-        activation = self.get_activation(claim_txo.tx_num, claim_txo.position)
-        claim = self._prepare_resolve_result(
-            claim_txo.tx_num, claim_txo.position, claim_hash, claim_txo.name, claim_txo.root_tx_num,
-            claim_txo.root_position, activation, claim_txo.channel_signature_is_valid
-        )
-        if not claim:
-            self.logger.warning("wat")
-            return
-        return self._prepare_claim_metadata(claim.claim_hash, claim)
 
-    def claims_producer(self, claim_hashes: Set[bytes]):
-        batch = []
-        results = []
 
-        for claim_hash in claim_hashes:
-            claim_txo = self.get_cached_claim_txo(claim_hash)
-            if not claim_txo:
-                self.logger.warning("can't sync non existent claim to ES: %s", claim_hash.hex())
-                continue
-            if not self.prefix_db.claim_takeover.get(claim_txo.normalized_name):
-                self.logger.warning("can't sync non existent claim to ES: %s", claim_hash.hex())
-                continue
-
-            activation = self.get_activation(claim_txo.tx_num, claim_txo.position)
-            claim = self._prepare_resolve_result(
-                claim_txo.tx_num, claim_txo.position, claim_hash, claim_txo.name, claim_txo.root_tx_num,
-                claim_txo.root_position, activation, claim_txo.channel_signature_is_valid
-            )
-            if claim:
-                batch.append(claim)
-
-        batch.sort(key=lambda x: x.tx_hash)
-
-        for claim in batch:
-            _meta = self._prepare_claim_metadata(claim.claim_hash, claim)
-            if _meta:
-                results.append(_meta)
-        return results

--- a/hub/herald/env.py
+++ b/hub/herald/env.py
@@ -11,7 +11,7 @@ class ServerEnv(Env):
                  session_timeout=None, drop_client=None, description=None, daily_fee=None,
                  database_query_timeout=None, elastic_notifier_host=None, elastic_notifier_port=None,
                  blocking_channel_ids=None, filtering_channel_ids=None, peer_hubs=None, peer_announce=None,
-                 index_address_status=None):
+                 index_address_status=None, address_history_cache_size=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
                          cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
@@ -50,6 +50,8 @@ class ServerEnv(Env):
         self.daily_fee = daily_fee if daily_fee is not None else self.string_amount('DAILY_FEE', '0')
         self.database_query_timeout = (database_query_timeout / 1000.0) if database_query_timeout is not None else \
             (float(self.integer('QUERY_TIMEOUT_MS', 10000)) / 1000.0)
+        self.hashX_history_cache_size = address_history_cache_size if address_history_cache_size is not None \
+            else self.integer('ADDRESS_HISTORY_CACHE_SIZE', 1000)
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -96,6 +98,11 @@ class ServerEnv(Env):
         parser.add_argument('--daily_fee', default=cls.default('DAILY_FEE', '0'), type=str)
         parser.add_argument('--query_timeout_ms', type=int, default=cls.integer('QUERY_TIMEOUT_MS', 10000),
                             help="Elasticsearch query timeout, in ms. Can be set in env with 'QUERY_TIMEOUT_MS'")
+        parser.add_argument('--address_history_cache_size', type=int,
+                            default=cls.integer('ADDRESS_HISTORY_CACHE_SIZE', 1000),
+                            help="Size of the lru cache of address histories. "
+                                 "Can be set in the env with 'ADDRESS_HISTORY_CACHE_SIZE'")
+
     @classmethod
     def from_arg_parser(cls, args):
         return cls(
@@ -110,5 +117,6 @@ class ServerEnv(Env):
             drop_client=args.drop_client, description=args.description, daily_fee=args.daily_fee,
             database_query_timeout=args.query_timeout_ms, blocking_channel_ids=args.blocking_channel_ids,
             filtering_channel_ids=args.filtering_channel_ids, elastic_notifier_host=args.elastic_notifier_host,
-            elastic_notifier_port=args.elastic_notifier_port, index_address_status=args.index_address_statuses
+            elastic_notifier_port=args.elastic_notifier_port, index_address_status=args.index_address_statuses,
+            address_history_cache_size=args.address_history_cache_size
         )

--- a/hub/herald/mempool.py
+++ b/hub/herald/mempool.py
@@ -242,7 +242,7 @@ class HubMemPool:
                                                   (self.session_manager.hsub_results[session.subscribe_headers_raw],))
                     )
                 if hashXes:
-                    asyncio.create_task(session.send_history_notifications(*hashXes))
+                    asyncio.create_task(session.send_history_notifications(hashXes))
 
     async def _notify_sessions(self, height, touched, new_touched):
         """Notify sessions about height changes and touched addresses."""

--- a/hub/herald/session.py
+++ b/hub/herald/session.py
@@ -22,7 +22,7 @@ from hub.herald import PROTOCOL_MIN, PROTOCOL_MAX, HUB_PROTOCOL_VERSION
 from hub.build_info import BUILD, COMMIT_HASH, DOCKER_TAG
 from hub.herald.search import SearchIndex
 from hub.common import sha256, hash_to_hex_str, hex_str_to_hash, HASHX_LEN, version_string, formatted_time, SIZE_BUCKETS
-from hub.common import protocol_version, RPCError, DaemonError, TaskGroup, HISTOGRAM_BUCKETS
+from hub.common import protocol_version, RPCError, DaemonError, TaskGroup, HISTOGRAM_BUCKETS, asyncify_for_loop
 from hub.common import LRUCacheWithMetrics
 from hub.herald.jsonrpc import JSONRPCAutoDetect, JSONRPCConnection, JSONRPCv2, JSONRPC
 from hub.herald.common import BatchRequest, ProtocolError, Request, Batch, Notification
@@ -1181,33 +1181,39 @@ class LBRYElectrumX(asyncio.Protocol):
         status = sha256(history.encode())
         return status.hex()
 
-    async def send_history_notifications(self, *hashXes: typing.Iterable[bytes]):
+    async def get_hashX_statuses(self, hashXes: typing.List[bytes]):
+        if self.env.index_address_status:
+            return await self.db.get_hashX_statuses(hashXes)
+        return [await self.get_hashX_status(hashX) for hashX in hashXes]
+
+    async def send_history_notifications(self, hashXes: typing.List[bytes]):
         notifications = []
-        for hashX in hashXes:
+        start = time.perf_counter()
+        statuses = await self.get_hashX_statuses(hashXes)
+        duration = time.perf_counter() - start
+        self.session_manager.address_history_metric.observe(duration)
+        start = time.perf_counter()
+        scripthash_notifications = 0
+        address_notifications = 0
+        for hashX, status in zip(hashXes, statuses):
             alias = self.hashX_subs[hashX]
             if len(alias) == 64:
                 method = 'blockchain.scripthash.subscribe'
+                scripthash_notifications += 1
             else:
                 method = 'blockchain.address.subscribe'
-            start = time.perf_counter()
-            status = await self.get_hashX_status(hashX)
-            duration = time.perf_counter() - start
-            self.session_manager.address_history_metric.observe(duration)
-            notifications.append((method, (alias, status)))
-            if duration > 30:
-                self.logger.warning("slow history notification (%s) for '%s'", duration, alias)
-
-        start = time.perf_counter()
-        self.session_manager.notifications_in_flight_metric.inc()
-        for method, args in notifications:
-            self.NOTIFICATION_COUNT.labels(method=method,).inc()
+                address_notifications += 1
+            notifications.append(Notification(method, (alias, status)))
+        if scripthash_notifications:
+            self.NOTIFICATION_COUNT.labels(method='blockchain.scripthash.subscribe',).inc(scripthash_notifications)
+        if address_notifications:
+            self.NOTIFICATION_COUNT.labels(method='blockchain.address.subscribe', ).inc(address_notifications)
+        self.session_manager.notifications_in_flight_metric.inc(len(notifications))
         try:
-            await self.send_notifications(
-                Batch([Notification(method, (alias, status)) for (method, (alias, status)) in notifications])
-            )
+            await self.send_notifications(Batch(notifications))
             self.session_manager.notifications_sent_metric.observe(time.perf_counter() - start)
         finally:
-            self.session_manager.notifications_in_flight_metric.dec()
+            self.session_manager.notifications_in_flight_metric.dec(len(notifications))
 
     # def get_metrics_or_placeholder_for_api(self, query_name):
     #     """ Do not hold on to a reference to the metrics
@@ -1470,12 +1476,13 @@ class LBRYElectrumX(asyncio.Protocol):
         address: the address to subscribe to"""
         if len(addresses) > 1000:
             raise RPCError(BAD_REQUEST, f'too many addresses in subscription request: {len(addresses)}')
-        results = []
+        hashXes = [item async for item in asyncify_for_loop((self.address_to_hashX(address) for address in addresses), 100)]
+        statuses = await self.get_hashX_statuses(hashXes)
+        for hashX, alias in zip(hashXes, addresses):
+            self.hashX_subs[hashX] = alias
+            self.session_manager.hashx_subscriptions_by_session[hashX].add(id(self))
         self.session_manager.address_subscription_metric.inc(len(addresses))
-        for address in addresses:
-            results.append(await self.hashX_subscribe(self.address_to_hashX(address), address))
-            await asyncio.sleep(0)
-        return results
+        return statuses
 
     async def address_unsubscribe(self, address):
         """Unsubscribe an address.

--- a/hub/scribe/env.py
+++ b/hub/scribe/env.py
@@ -28,7 +28,7 @@ class BlockchainEnv(Env):
                             help='This setting translates into the max_open_files option given to rocksdb. '
                                  'A higher number will use more memory. Defaults to 64.')
         parser.add_argument('--address_history_cache_size', type=int,
-                            default=cls.integer('ADDRESS_HISTORY_CACHE_SIZE', 1000),
+                            default=cls.integer('ADDRESS_HISTORY_CACHE_SIZE', 2 ** 13),
                             help="LRU cache size for address histories, used when processing new blocks "
                                  "and when processing mempool updates. Can be set in env with "
                                  "'ADDRESS_HISTORY_CACHE_SIZE'")

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -118,8 +118,8 @@ class BlockchainProcessorService(BlockchainService):
         self.pending_transaction_num_mapping: Dict[bytes, int] = {}
         self.pending_transactions: Dict[int, bytes] = {}
 
-        self.hashX_history_cache = LRUCache(min(100, max(0, env.hashX_history_cache_size)))
-        self.hashX_full_cache = LRUCache(min(100, max(0, env.hashX_history_cache_size)))
+        self.hashX_history_cache = LRUCache(max(100, env.hashX_history_cache_size))
+        self.hashX_full_cache = LRUCache(max(100, env.hashX_history_cache_size))
         self.history_tx_info_cache = LRUCache(2 ** 16)
 
     def open_db(self):


### PR DESCRIPTION
- updates sending address notifications to use batched/multi_get lookups instead of single `get` calls
- refactors `resolve` to do a minimal series of multi_get lookups for a batch of urls to resolve, instead of resolving each url on its own
ref: #44 