### PR TITLE
Use LFU caches for address status and history calculation in scribe and herald

### DIFF
--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -18,7 +18,7 @@ from hub.schema.url import URL, normalize_name
 from hub.schema.claim import guess_stream_type
 from hub.schema.result import Censor
 from hub.scribe.transaction import TxInput
-from hub.common import hash_to_hex_str, LRUCacheWithMetrics
+from hub.common import hash_to_hex_str, LRUCacheWithMetrics, LFUCacheWithMetrics
 from hub.db.merkle import Merkle, MerkleCache, FastMerkleCacheItem
 from hub.db.common import ResolveResult, ExpandedResolveResult, DBError, UTXO
 from hub.db.prefixes import PendingActivationValue, ClaimTakeoverValue, ClaimToTXOValue, PrefixDB
@@ -90,9 +90,9 @@ class SecondaryDB:
         self.header_mc = MerkleCache(self.merkle, self.fs_block_hashes)
 
         # lru cache of tx_hash: (tx_bytes, tx_num, position, tx_height)
-        self.tx_cache = LRUCacheWithMetrics(tx_cache_size, metric_name='tx', namespace=NAMESPACE)
+        self.tx_cache = LFUCacheWithMetrics(tx_cache_size, metric_name='tx', namespace=NAMESPACE)
         # lru cache of block heights to merkle trees of the block tx hashes
-        self.merkle_cache = LRUCacheWithMetrics(merkle_cache_size, metric_name='merkle', namespace=NAMESPACE)
+        self.merkle_cache = LFUCacheWithMetrics(merkle_cache_size, metric_name='merkle', namespace=NAMESPACE)
 
         # these are only used if the cache_all_tx_hashes setting is on
         self.total_transactions: List[bytes] = []

--- a/hub/herald/env.py
+++ b/hub/herald/env.py
@@ -12,7 +12,8 @@ class ServerEnv(Env):
                  database_query_timeout=None, elastic_notifier_host=None, elastic_notifier_port=None,
                  blocking_channel_ids=None, filtering_channel_ids=None, peer_hubs=None, peer_announce=None,
                  index_address_status=None, address_history_cache_size=None, daemon_ca_path=None,
-                 merkle_cache_size=None, resolved_url_cache_size=None, tx_cache_size=None):
+                 merkle_cache_size=None, resolved_url_cache_size=None, tx_cache_size=None,
+                 history_tx_cache_size=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
                          cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
@@ -59,6 +60,8 @@ class ServerEnv(Env):
             'RESOLVED_URL_CACHE_SIZE', 32768)
         self.tx_cache_size = tx_cache_size if tx_cache_size is not None else self.integer(
             'TX_CACHE_SIZE', 32768)
+        self.history_tx_cache_size = history_tx_cache_size if history_tx_cache_size is not None else \
+            self.integer('HISTORY_TX_CACHE_SIZE', 524288)
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -123,6 +126,11 @@ class ServerEnv(Env):
                             default=cls.integer('TX_CACHE_SIZE', 32768),
                             help="Size of the lru cache of transactions. "
                                  "Can be set in the env with 'TX_CACHE_SIZE'")
+        parser.add_argument('--history_tx_cache_size', type=int,
+                            default=cls.integer('HISTORY_TX_CACHE_SIZE', 524288),
+                            help="Size of the lfu cache of txids in transaction histories for addresses. "
+                                 "Can be set in the env with 'HISTORY_TX_CACHE_SIZE'")
+
     @classmethod
     def from_arg_parser(cls, args):
         return cls(
@@ -140,5 +148,5 @@ class ServerEnv(Env):
             elastic_notifier_port=args.elastic_notifier_port, index_address_status=args.index_address_statuses,
             address_history_cache_size=args.address_history_cache_size, daemon_ca_path=args.daemon_ca_path,
             merkle_cache_size=args.merkle_cache_size, resolved_url_cache_size=args.resolved_url_cache_size,
-            tx_cache_size=args.tx_cache_size
+            tx_cache_size=args.tx_cache_size, history_tx_cache_size=args.history_tx_cache_size
         )

--- a/hub/herald/session.py
+++ b/hub/herald/session.py
@@ -214,11 +214,11 @@ class SessionManager:
         )
         self.running = False
         # hashX: List[int]
-        self.hashX_raw_history_cache = LFUCacheWithMetrics(2 ** 16, metric_name='raw_history', namespace=NAMESPACE)
+        self.hashX_raw_history_cache = LFUCacheWithMetrics(env.hashX_history_cache_size, metric_name='raw_history', namespace=NAMESPACE)
         # hashX: List[CachedAddressHistoryItem]
-        self.hashX_history_cache = LFUCacheWithMetrics(2 ** 14, metric_name='full_history', namespace=NAMESPACE)
+        self.hashX_history_cache = LFUCacheWithMetrics(env.hashX_history_cache_size, metric_name='full_history', namespace=NAMESPACE)
         # tx_num: Tuple[txid, height]
-        self.history_tx_info_cache = LFUCacheWithMetrics(2 ** 17, metric_name='history_tx', namespace=NAMESPACE)
+        self.history_tx_info_cache = LFUCacheWithMetrics(env.history_tx_cache_size, metric_name='history_tx', namespace=NAMESPACE)
 
     def clear_caches(self):
         self.resolve_cache.clear()

--- a/hub/scribe/daemon.py
+++ b/hub/scribe/daemon.py
@@ -62,7 +62,7 @@ class LBCDaemon:
             self.connector = aiohttp.TCPConnector(ssl_context=ssl_context)
         else:
             self.connector = aiohttp.TCPConnector(ssl=False)
-        self._block_hash_cache = LRUCacheWithMetrics(1024)
+        self._block_hash_cache = LRUCacheWithMetrics(1024, metric_name='block_hash', namespace=NAMESPACE)
         self._block_cache = LRUCacheWithMetrics(64, metric_name='block', namespace=NAMESPACE)
 
     async def close(self):

--- a/hub/scribe/env.py
+++ b/hub/scribe/env.py
@@ -18,7 +18,7 @@ class BlockchainEnv(Env):
             if isinstance(rebuild_address_status_from_height, int) else -1
         self.daemon_ca_path = daemon_ca_path if daemon_ca_path else None
         self.history_tx_cache_size = history_tx_cache_size if history_tx_cache_size is not None else \
-            self.integer('HISTORY_TX_CACHE_SIZE', 262144)
+            self.integer('HISTORY_TX_CACHE_SIZE', 524288)
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -42,9 +42,9 @@ class BlockchainEnv(Env):
                             help="Rebuild address statuses, set to 0 to reindex all address statuses or provide a "
                                  "block height to start reindexing from. Defaults to -1 (off).")
         parser.add_argument('--history_tx_cache_size', type=int,
-                            default=cls.integer('HISTORY_TX_CACHE_SIZE', 262144),
+                            default=cls.integer('HISTORY_TX_CACHE_SIZE', 524288),
                             help="Size of the lfu cache of txids in transaction histories for addresses. "
-                                 "Can be set in the env with 'TX_CACHE_SIZE'")
+                                 "Can be set in the env with 'HISTORY_TX_CACHE_SIZE'")
 
     @classmethod
     def from_arg_parser(cls, args):

--- a/hub/scribe/env.py
+++ b/hub/scribe/env.py
@@ -18,7 +18,7 @@ class BlockchainEnv(Env):
             if isinstance(rebuild_address_status_from_height, int) else -1
         self.daemon_ca_path = daemon_ca_path if daemon_ca_path else None
         self.history_tx_cache_size = history_tx_cache_size if history_tx_cache_size is not None else \
-            self.integer('HISTORY_TX_CACHE_SIZE', 524288)
+            self.integer('HISTORY_TX_CACHE_SIZE', 4194304)
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -42,7 +42,7 @@ class BlockchainEnv(Env):
                             help="Rebuild address statuses, set to 0 to reindex all address statuses or provide a "
                                  "block height to start reindexing from. Defaults to -1 (off).")
         parser.add_argument('--history_tx_cache_size', type=int,
-                            default=cls.integer('HISTORY_TX_CACHE_SIZE', 524288),
+                            default=cls.integer('HISTORY_TX_CACHE_SIZE', 4194304),
                             help="Size of the lfu cache of txids in transaction histories for addresses. "
                                  "Can be set in the env with 'HISTORY_TX_CACHE_SIZE'")
 

--- a/hub/scribe/env.py
+++ b/hub/scribe/env.py
@@ -7,7 +7,7 @@ class BlockchainEnv(Env):
                  blocking_channel_ids=None, filtering_channel_ids=None,
                  db_max_open_files=64, daemon_url=None, hashX_history_cache_size=None,
                  index_address_status=None, rebuild_address_status_from_height=None,
-                 daemon_ca_path=None):
+                 daemon_ca_path=None, history_tx_cache_size=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
                          cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.db_max_open_files = db_max_open_files
@@ -17,6 +17,8 @@ class BlockchainEnv(Env):
         self.rebuild_address_status_from_height = rebuild_address_status_from_height \
             if isinstance(rebuild_address_status_from_height, int) else -1
         self.daemon_ca_path = daemon_ca_path if daemon_ca_path else None
+        self.history_tx_cache_size = history_tx_cache_size if history_tx_cache_size is not None else \
+            self.integer('HISTORY_TX_CACHE_SIZE', 262144)
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -39,6 +41,10 @@ class BlockchainEnv(Env):
         parser.add_argument('--rebuild_address_status_from_height', type=int, default=-1,
                             help="Rebuild address statuses, set to 0 to reindex all address statuses or provide a "
                                  "block height to start reindexing from. Defaults to -1 (off).")
+        parser.add_argument('--history_tx_cache_size', type=int,
+                            default=cls.integer('HISTORY_TX_CACHE_SIZE', 262144),
+                            help="Size of the lfu cache of txids in transaction histories for addresses. "
+                                 "Can be set in the env with 'TX_CACHE_SIZE'")
 
     @classmethod
     def from_arg_parser(cls, args):
@@ -49,5 +55,5 @@ class BlockchainEnv(Env):
             cache_all_claim_txos=args.cache_all_claim_txos, index_address_status=args.index_address_statuses,
             hashX_history_cache_size=args.address_history_cache_size,
             rebuild_address_status_from_height=args.rebuild_address_status_from_height,
-            daemon_ca_path=args.daemon_ca_path
+            daemon_ca_path=args.daemon_ca_path, history_tx_cache_size=args.history_tx_cache_size
         )

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -1745,6 +1745,7 @@ class BlockchainProcessorService(BlockchainService):
         await self.run_in_thread_with_lock(flush)
 
     def _iter_start_tasks(self):
+        self.block_count_metric.set(0 if not self.last_state else self.last_state.height)
         yield self.start_prometheus()
         while self.db.db_version < max(self.db.DB_VERSIONS):
             if self.db.db_version == 7:

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -11,7 +11,7 @@ from hub import PROMETHEUS_NAMESPACE
 from hub.db.prefixes import ACTIVATED_SUPPORT_TXO_TYPE, ACTIVATED_CLAIM_TXO_TYPE
 from hub.db.prefixes import PendingActivationKey, PendingActivationValue, ClaimToTXOValue
 from hub.error.base import ChainError
-from hub.common import hash_to_hex_str, hash160, RPCError, HISTOGRAM_BUCKETS, StagedClaimtrieItem, sha256, LRUCache
+from hub.common import hash_to_hex_str, hash160, RPCError, HISTOGRAM_BUCKETS, StagedClaimtrieItem, sha256, LFUCache, LRUCache
 from hub.scribe.db import PrimaryDB
 from hub.scribe.daemon import LBCDaemon
 from hub.scribe.transaction import Tx, TxOutput, TxInput, Block
@@ -122,9 +122,9 @@ class BlockchainProcessorService(BlockchainService):
         self.pending_transaction_num_mapping: Dict[bytes, int] = {}
         self.pending_transactions: Dict[int, bytes] = {}
 
-        self.hashX_history_cache = LRUCache(max(100, env.hashX_history_cache_size))
-        self.hashX_full_cache = LRUCache(max(100, env.hashX_history_cache_size))
-        self.history_tx_info_cache = LRUCache(2 ** 16)
+        self.hashX_history_cache = LFUCache(max(100, env.hashX_history_cache_size))
+        self.hashX_full_cache = LFUCache(max(100, env.hashX_history_cache_size))
+        self.history_tx_info_cache = LFUCache(2 ** 17)
 
     def open_db(self):
         env = self.env


### PR DESCRIPTION
This replaces existing LRU caches with LFU caches (used calculating address statuses and reading address histories), as to have a better overall hit rate by better keeping the intersecting sets of historical txids that are in the histories for many addresses as they are used in new txs in mempool/blocks.

With the new cache type the `--cache_all_tx_hashes` setting is no longer needed to quickly keep up mempool and new blocks with `--index_address_statuses`, this saves quite a bit of memory for similar performance, down from ~15gb to ~6gb. With the scribe default `--history_tx_cache_size` of 4194304 the cache will have an average hit rate of ~88%, going to 98-100% during load spikes, which gives it close enough performance to having the list of items being cached entirely stored in memory, but for less resources needed.