### PR TITLE
Fix out-of-memory crash in herald

### DIFF
--- a/hub/herald/env.py
+++ b/hub/herald/env.py
@@ -61,7 +61,7 @@ class ServerEnv(Env):
         self.tx_cache_size = tx_cache_size if tx_cache_size is not None else self.integer(
             'TX_CACHE_SIZE', 32768)
         self.history_tx_cache_size = history_tx_cache_size if history_tx_cache_size is not None else \
-            self.integer('HISTORY_TX_CACHE_SIZE', 524288)
+            self.integer('HISTORY_TX_CACHE_SIZE', 4194304)
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):

--- a/hub/herald/service.py
+++ b/hub/herald/service.py
@@ -62,7 +62,6 @@ class HubServerService(BlockchainReaderService):
 
     def unwind(self):
         self.session_manager.hashX_raw_history_cache.clear()
-        self.session_manager.hashX_history_cache.clear()
         prev_count = self.db.tx_counts.pop()
         tx_count = self.db.tx_counts[-1]
         self.db.block_hashes.pop()


### PR DESCRIPTION
This removes `hashX_history_cache`, a cache that was redundant (vs `hashX_raw_history_cache` and `history_tx_info_cache`) and would cause memory usage spikes upon new blocks (trying to pre-cache address histories).
