### PR TITLE
Treat lbcd RPC response=None as a WarmingUpError.

### DIFF
--- a/hub/scribe/daemon.py
+++ b/hub/scribe/daemon.py
@@ -183,6 +183,8 @@ class LBCDaemon:
         start = time.perf_counter()
 
         def processor(result):
+            if result is None:
+                raise WarmingUpError
             err = result['error']
             if not err:
                 return result['result']
@@ -207,6 +209,8 @@ class LBCDaemon:
         start = time.perf_counter()
 
         def processor(result):
+            if result is None:
+                raise WarmingUpError
             errs = [item['error'] for item in result if item['error']]
             if any(err.get('code') == self.WARMING_UP for err in errs):
                 raise WarmingUpError


### PR DESCRIPTION
Fixes #92 

It seems like this is a transient state similar to the "warming up" state that happens during reorg tests. The problem is that `result=None` so `result['error']` raises an exception. When the block fetcher loop crashes, the test (reorg_drop_claim, reorg_change_claim_height) times out.