### PR TITLE
Improve scribe sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,7 @@ For various reasons it may be desirable to block or filtering content from claim
   - `--host` Interface for server to listen on, use 0.0.0.0 to listen on the external interface. Can be set from the environment with `HOST`
   - `--tcp_port` Electrum TCP port to listen on for hub server. Can be set from the environment with `TCP_PORT`
   - `--udp_port` UDP port to listen on for hub server. Can be set from the environment with `UDP_PORT`
-  - `--elastic_host` Hostname or ip address of the elasticsearch instance to connect to. Can be set from the environment with `ELASTIC_HOST`
-  - `--elastic_port` Elasticsearch port to connect to. Can be set from the environment with `ELASTIC_PORT`
-  - `--elastic_notifier_host` Elastic sync notifier host to connect to, defaults to localhost. Can be set from the environment with `ELASTIC_NOTIFIER_HOST`
-  - `--elastic_notifier_port` Elastic sync notifier port to connect using. Can be set from the environment with `ELASTIC_NOTIFIER_PORT`
+  - `--elastic_services` Comma separated list of items in the format `elastic_host:elastic_port/notifier_host:notifier_port`. Can be set from the environment with `ELASTIC_SERVICES`
   - `--query_timeout_ms` Timeout for claim searches in elasticsearch in milliseconds. Can be set from the environment with `QUERY_TIMEOUT_MS`
   - `--blocking_channel_ids` Space separated list of channel claim ids used for blocking. Claims that are reposted by these channels can't be resolved or returned in search results. Can be set from the environment with `BLOCKING_CHANNEL_IDS`.
   - `--filtering_channel_ids` Space separated list of channel claim ids used for blocking. Claims that are reposted by these channels aren't returned in search results. Can be set from the environment with `FILTERING_CHANNEL_IDS`

--- a/docs/docker_examples/docker-compose.yml
+++ b/docs/docker_examples/docker-compose.yml
@@ -17,11 +17,10 @@ services:
       - "lbry_rocksdb:/database"
     environment:
       - HUB_COMMAND=scribe
-      - SNAPSHOT_URL=https://snapshots.lbry.com/hub/lbry-rocksdb.zip
+      - SNAPSHOT_URL=https://snapshots.lbry.com/hub/block_1256013/lbry-rocksdb.tar
     command:  # for full options, see `scribe --help`
       - "--daemon_url=http://lbry:lbry@127.0.0.1:9245"
       - "--max_query_workers=2"
-      # - "--cache_all_tx_hashes"  # uncomment to keep an index of all tx hashes in memory. This uses lots (10+g) of memory but substantially improves performance.
       - "--index_address_statuses"
   scribe_elastic_sync:
     depends_on:

--- a/docs/docker_examples/docker-compose.yml
+++ b/docs/docker_examples/docker-compose.yml
@@ -35,14 +35,12 @@ services:
       - "lbry_rocksdb:/database"
     environment:
       - HUB_COMMAND=scribe-elastic-sync
-      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8
-      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6
+      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8 d4612c256a44fc025c37a875751415299b1f8220
+      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6 145265bd234b7c9c28dfc6857d878cca402dda94 22335fbb132eee86d374b613875bf88bec83492f f665b89b999f411aa5def311bb2eb385778d49c8
     command:  # for full options, see `scribe-elastic-sync --help`
       - "--max_query_workers=2"
       - "--elastic_host=127.0.0.1"            # elasticsearch host
       - "--elastic_port=9200"                 # elasticsearch port
-      - "--elastic_notifier_host=127.0.0.1"   # address for the elastic sync notifier to connect to
-      - "--elastic_notifier_port=19080"
   herald:
     depends_on:
       - lbcd
@@ -58,18 +56,15 @@ services:
       - "lbry_rocksdb:/database"
     environment:
       - HUB_COMMAND=herald
-      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8
-      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6
+      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8 d4612c256a44fc025c37a875751415299b1f8220
+      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6 145265bd234b7c9c28dfc6857d878cca402dda94 22335fbb132eee86d374b613875bf88bec83492f f665b89b999f411aa5def311bb2eb385778d49c8
     command:  # for full options, see `herald --help`
       - "--index_address_statuses"
       - "--daemon_url=http://lbry:lbry@127.0.0.1:9245"
       - "--max_query_workers=4"
       - "--host=0.0.0.0"
+      - "--elastic_services=127.0.0.1:9200/127.0.0.1:19080"
       - "--prometheus_port=2112"              # comment out to disable prometheus metrics
-      # - "--elastic_host=127.0.0.1"            # elasticsearch host
-      # - "--elastic_port=9200"                 # elasticsearch port
-      # - "--elastic_notifier_host=127.0.0.1"   # address for the elastic sync notifier to connect to
-      # - "--elastic_notifier_port=19080"
       # - "--max_sessions=100000              # uncomment to increase the maximum number of electrum connections, defaults to 1000
       # - "--allow_lan_udp"                   # uncomment to reply to clients on the local network
   es01:

--- a/docs/docker_examples/hub-compose.yml
+++ b/docs/docker_examples/hub-compose.yml
@@ -29,8 +29,8 @@ services:
       - "lbry_rocksdb:/database"
     environment:
       - HUB_COMMAND=scribe-elastic-sync
-      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8
-      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6
+      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8 d4612c256a44fc025c37a875751415299b1f8220
+      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6 145265bd234b7c9c28dfc6857d878cca402dda94 22335fbb132eee86d374b613875bf88bec83492f f665b89b999f411aa5def311bb2eb385778d49c8
     command:
       - "--elastic_host=127.0.0.1"
       - "--elastic_port=9200"
@@ -49,12 +49,11 @@ services:
       - "lbry_rocksdb:/database"
     environment:
       - HUB_COMMAND=herald
-      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8
-      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6
+      - FILTERING_CHANNEL_IDS=770bd7ecba84fd2f7607fb15aedd2b172c2e153f 95e5db68a3101df19763f3a5182e4b12ba393ee8 d4612c256a44fc025c37a875751415299b1f8220
+      - BLOCKING_CHANNEL_IDS=dd687b357950f6f271999971f43c785e8067c3a9 06871aa438032244202840ec59a469b303257cad b4a2528f436eca1bf3bf3e10ff3f98c57bd6c4c6 145265bd234b7c9c28dfc6857d878cca402dda94 22335fbb132eee86d374b613875bf88bec83492f f665b89b999f411aa5def311bb2eb385778d49c8
     command:
       - "--daemon_url=http://lbry:lbry@127.0.0.1:9245"
-      - "--elastic_host=127.0.0.1"
-      - "--elastic_port=9200"
+      - "--elastic_services=127.0.0.1:9200/127.0.0.1:19080"
       - "--max_query_workers=4"
       - "--host=0.0.0.0"
       - "--max_sessions=100000"

--- a/docs/docker_examples/hub-compose.yml
+++ b/docs/docker_examples/hub-compose.yml
@@ -14,11 +14,10 @@ services:
       - "lbry_rocksdb:/database"
     environment:
       - HUB_COMMAND=scribe
-      - SNAPSHOT_URL=https://snapshots.lbry.com/hub/lbry-rocksdb.zip
+      - SNAPSHOT_URL=https://snapshots.lbry.com/hub/block_1256013/lbry-rocksdb.tar
     command:
       - "--daemon_url=http://lbry:lbry@127.0.0.1:9245"
       - "--max_query_workers=2"
-      - "--cache_all_tx_hashes"
   scribe_elastic_sync:
     image: lbry/hub:${SCRIBE_TAG:-master}
     restart: always

--- a/hub/db/common.py
+++ b/hub/db/common.py
@@ -50,6 +50,7 @@ class DB_PREFIXES(enum.Enum):
     hashX_mempool_status = b'g'
     reposted_count = b'j'
     effective_amount = b'i'
+    future_effective_amount = b'k'
 
 
 COLUMN_SETTINGS = {}  # this is updated by the PrefixRow metaclass

--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -1321,7 +1321,8 @@ class SecondaryDB:
             for tx_hash_bytes, tx in zip(needed_mempool, await run_in_executor(
                     self._executor, self.prefix_db.mempool_tx.multi_get, [(tx_hash,) for tx_hash in needed_mempool],
                     True, False)):
-                self.tx_cache[tx_hash_bytes] = tx, None, None, -1
+                if tx is not None:
+                    self.tx_cache[tx_hash_bytes] = tx, None, None, -1
                 tx_infos[tx_hash_bytes[::-1].hex()] = None if not tx else tx.hex(), {'block_height': -1}
                 await asyncio.sleep(0)
         return {txid: tx_infos.get(txid) for txid in txids}  # match ordering of the txs in the request

--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -34,7 +34,7 @@ NAMESPACE = f"{PROMETHEUS_NAMESPACE}_db"
 
 
 class SecondaryDB:
-    DB_VERSIONS = [7, 8, 9, 10, 11]
+    DB_VERSIONS = [7, 8, 9, 10, 11, 12]
 
     def __init__(self, coin, db_dir: str, secondary_name: str, max_open_files: int = -1, reorg_limit: int = 200,
                  cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,

--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -790,7 +790,7 @@ class SecondaryDB:
         for touched in claim_hashes:
             extra = {}
             claim_txo = claims[touched]
-            if not claim_txo:
+            if not claim_txo or (claim_txo and not controlling_claims[claim_txo.normalized_name]):
                 yield touched, None, extra
                 continue
             if touched in total_extra:

--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -524,11 +524,16 @@ class SecondaryDB:
             if not v:
                 return 0
             return v.activated_sum - v.activated_support_sum
+        amount = 0
+        v = self.prefix_db.effective_amount.get(claim_hash)
+        if v:
+            amount = v.activated_sum - v.activated_support_sum
         for v in self.prefix_db.active_amount.iterate(
-                start=(claim_hash, ACTIVATED_CLAIM_TXO_TYPE, 0), stop=(claim_hash, ACTIVATED_CLAIM_TXO_TYPE, height),
+                start=(claim_hash, ACTIVATED_CLAIM_TXO_TYPE, self.db_height + 1),
+                stop=(claim_hash, ACTIVATED_CLAIM_TXO_TYPE, height),
                 include_key=False, reverse=True):
             return v.amount
-        return 0
+        return amount
 
     def get_effective_amount(self, claim_hash: bytes) -> int:
         v = self.prefix_db.effective_amount.get(claim_hash)

--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -1137,6 +1137,17 @@ class SecondaryDB:
             return self.tx_num_mapping[tx_hash]
         return self.prefix_db.tx_num.get(tx_hash).tx_num
 
+    def get_tx_nums(self, tx_hashes: List[bytes]) -> Dict[bytes, Optional[int]]:
+        if not tx_hashes:
+            return {}
+        if self._cache_all_tx_hashes:
+            return {tx_hash: self.tx_num_mapping[tx_hash] for tx_hash in tx_hashes}
+        return {
+            k: None if not v else v.tx_num for k, v in zip(
+                tx_hashes, self.prefix_db.tx_num.multi_get([(tx_hash,) for tx_hash in tx_hashes])
+            )
+        }
+
     def get_cached_claim_txo(self, claim_hash: bytes) -> Optional[ClaimToTXOValue]:
         if self._cache_all_claim_txos:
             return self.claim_to_txo.get(claim_hash)

--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -1166,9 +1166,6 @@ class SecondaryDB:
         v = self.prefix_db.txo_to_claim.get_pending(tx_num, position)
         return None if not v else v.claim_hash
 
-    def get_cached_claim_exists(self, tx_num: int, position: int) -> bool:
-        return self.get_cached_claim_hash(tx_num, position) is not None
-
     # Header merkle cache
 
     async def populate_header_merkle_cache(self):

--- a/hub/db/db.py
+++ b/hub/db/db.py
@@ -40,7 +40,8 @@ class SecondaryDB:
                  cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,
                  blocking_channel_ids: List[str] = None,
                  filtering_channel_ids: List[str] = None, executor: ThreadPoolExecutor = None,
-                 index_address_status=False, merkle_cache_size=32768, tx_cache_size=32768):
+                 index_address_status=False, merkle_cache_size=32768, tx_cache_size=32768,
+                 enforce_integrity=True):
         self.logger = logging.getLogger(__name__)
         self.coin = coin
         self._executor = executor
@@ -53,6 +54,7 @@ class SecondaryDB:
             assert max_open_files == -1, 'max open files must be -1 for secondary readers'
         self._db_max_open_files = max_open_files
         self._index_address_status = index_address_status
+        self._enforce_integrity = enforce_integrity
         self.prefix_db: typing.Optional[PrefixDB] = None
 
         self.hist_unflushed = defaultdict(partial(array.array, 'I'))
@@ -1016,7 +1018,7 @@ class SecondaryDB:
         self.prefix_db = PrefixDB(
             db_path, reorg_limit=self._reorg_limit, max_open_files=self._db_max_open_files,
             unsafe_prefixes={DBStatePrefixRow.prefix, MempoolTXPrefixRow.prefix, HashXMempoolStatusPrefixRow.prefix},
-            secondary_path=secondary_path
+            secondary_path=secondary_path, enforce_integrity=self._enforce_integrity
         )
 
         if secondary_path != '':

--- a/hub/db/interface.py
+++ b/hub/db/interface.py
@@ -183,7 +183,8 @@ class BasePrefixDB:
     UNDO_KEY_STRUCT = struct.Struct(b'>Q32s')
     PARTIAL_UNDO_KEY_STRUCT = struct.Struct(b'>Q')
 
-    def __init__(self, path, max_open_files=64, secondary_path='', max_undo_depth: int = 200, unsafe_prefixes=None):
+    def __init__(self, path, max_open_files=64, secondary_path='', max_undo_depth: int = 200, unsafe_prefixes=None,
+                 enforce_integrity=True):
         column_family_options = {}
         for prefix in DB_PREFIXES:
             settings = COLUMN_SETTINGS[prefix.value]
@@ -206,7 +207,9 @@ class BasePrefixDB:
                 cf = self._db.get_column_family(prefix.value)
             self.column_families[prefix.value] = cf
 
-        self._op_stack = RevertableOpStack(self.get, self.multi_get, unsafe_prefixes=unsafe_prefixes)
+        self._op_stack = RevertableOpStack(
+            self.get, self.multi_get, unsafe_prefixes=unsafe_prefixes, enforce_integrity=enforce_integrity
+        )
         self._max_undo_depth = max_undo_depth
 
     def unsafe_commit(self):

--- a/hub/db/interface.py
+++ b/hub/db/interface.py
@@ -283,10 +283,8 @@ class BasePrefixDB:
         if len(keys) == 0:
             return []
         first_key = keys[0]
-        if not all(first_key[0] == key[0] for key in keys):
-            raise ValueError('cannot multi-delete across column families')
-        cf = self.column_families[first_key[:1]]
-        db_result = self._db.multi_get([(cf, k) for k in keys], fill_cache=fill_cache)
+        get_cf = self.column_families.__getitem__
+        db_result = self._db.multi_get([(get_cf(k[:1]), k) for k in keys], fill_cache=fill_cache)
         return list(db_result.values())
 
     def multi_delete(self, items: typing.List[typing.Tuple[bytes, bytes]]):

--- a/hub/db/migrators/migrate11to12.py
+++ b/hub/db/migrators/migrate11to12.py
@@ -1,0 +1,57 @@
+import logging
+from collections import defaultdict
+
+FROM_VERSION = 11
+TO_VERSION = 12
+
+
+def migrate(db):
+    log = logging.getLogger(__name__)
+    prefix_db = db.prefix_db
+
+    log.info("migrating the db to version 12")
+
+    effective_amounts = defaultdict(int)
+
+    log.info("deleting any existing future effective amounts")
+
+    to_delete = list(prefix_db.future_effective_amount.iterate(deserialize_key=False, deserialize_value=False))
+    while to_delete:
+        batch, to_delete = to_delete[:100000], to_delete[100000:]
+        if batch:
+            prefix_db.multi_delete(batch)
+            prefix_db.unsafe_commit()
+
+    log.info("calculating future claim effective amounts for the new index at block %i", db.db_height)
+    cnt = 0
+    for k, v in prefix_db.active_amount.iterate():
+        cnt += 1
+        effective_amounts[k.claim_hash] += v.amount
+        if cnt % 1000000 == 0:
+            log.info("scanned %i amounts for %i claims", cnt, len(effective_amounts))
+    log.info("preparing to insert future effective amounts")
+
+    effective_amounts_to_put = [
+        prefix_db.future_effective_amount.pack_item(claim_hash, effective_amount)
+        for claim_hash, effective_amount in effective_amounts.items()
+    ]
+
+    log.info("inserting %i future effective amounts", len(effective_amounts_to_put))
+
+    cnt = 0
+
+    while effective_amounts_to_put:
+        batch, effective_amounts_to_put = effective_amounts_to_put[:100000], effective_amounts_to_put[100000:]
+        if batch:
+            prefix_db.multi_put(batch)
+            prefix_db.unsafe_commit()
+            cnt += len(batch)
+            if cnt % 1000000 == 0:
+                log.info("inserted effective amounts for %i claims", cnt)
+
+    log.info("finished building the effective amount index")
+
+    db.db_version = 12
+    db.write_db_state()
+    db.prefix_db.unsafe_commit()
+    log.info("finished migration to version 12")

--- a/hub/db/prefixes.py
+++ b/hub/db/prefixes.py
@@ -1799,6 +1799,7 @@ class EffectiveAmountPrefixRow(PrefixRow):
 
     @classmethod
     def pack_value(cls, effective_amount: int, support_sum: int) -> bytes:
+        assert effective_amount >= support_sum
         return super().pack_value(effective_amount, support_sum)
 
     @classmethod

--- a/hub/db/prefixes.py
+++ b/hub/db/prefixes.py
@@ -1292,7 +1292,7 @@ class UTXOPrefixRow(PrefixRow):
     prefix = DB_PREFIXES.utxo.value
     key_struct = struct.Struct(b'>11sLH')
     value_struct = struct.Struct(b'>Q')
-
+    cache_size = 1024 * 1024 * 64
     key_part_lambdas = [
         lambda: b'',
         struct.Struct(b'>11s').pack,
@@ -1325,7 +1325,7 @@ class HashXUTXOPrefixRow(PrefixRow):
     prefix = DB_PREFIXES.hashx_utxo.value
     key_struct = struct.Struct(b'>4sLH')
     value_struct = struct.Struct(b'>11s')
-
+    cache_size = 1024 * 1024 * 64
     key_part_lambdas = [
         lambda: b'',
         struct.Struct(b'>4s').pack,

--- a/hub/db/prefixes.py
+++ b/hub/db/prefixes.py
@@ -1852,9 +1852,11 @@ class FutureEffectiveAmountPrefixRow(PrefixRow):
 
 class PrefixDB(BasePrefixDB):
     def __init__(self, path: str, reorg_limit: int = 200, max_open_files: int = 64,
-                 secondary_path: str = '', unsafe_prefixes: Optional[typing.Set[bytes]] = None):
+                 secondary_path: str = '', unsafe_prefixes: Optional[typing.Set[bytes]] = None,
+                 enforce_integrity: bool = True):
         super().__init__(path, max_open_files=max_open_files, secondary_path=secondary_path,
-                         max_undo_depth=reorg_limit, unsafe_prefixes=unsafe_prefixes)
+                         max_undo_depth=reorg_limit, unsafe_prefixes=unsafe_prefixes,
+                         enforce_integrity=enforce_integrity)
         db = self._db
         self.claim_to_support = ClaimToSupportPrefixRow(db, self._op_stack)
         self.support_to_claim = SupportToClaimPrefixRow(db, self._op_stack)

--- a/hub/db/revertable.py
+++ b/hub/db/revertable.py
@@ -1,8 +1,8 @@
 import struct
 import logging
 from string import printable
-from collections import defaultdict
-from typing import Tuple, Iterable, Callable, Optional, List
+from collections import defaultdict, deque
+from typing import Tuple, Iterable, Callable, Optional, List, Deque
 from hub.db.common import DB_PREFIXES
 
 _OP_STRUCT = struct.Struct('>BLL')
@@ -97,8 +97,75 @@ class RevertableOpStack:
         """
         self._get = get_fn
         self._multi_get = multi_get_fn
+        # a defaultdict of verified ops ready to be applied
         self._items = defaultdict(list)
+        # a faster deque of ops that have not yet been checked for integrity errors
+        self._stash: Deque[RevertableOp] = deque()
+        self._stashed_last_op_for_key = {}
         self._unsafe_prefixes = unsafe_prefixes or set()
+
+    def stash_ops(self, ops: Iterable[RevertableOp]):
+        self._stash.extend(ops)
+        for op in ops:
+            self._stashed_last_op_for_key[op.key] = op
+
+    def validate_and_apply_stashed_ops(self):
+        if not self._stash:
+            return
+
+        ops_to_apply = []
+        append_op_needed = ops_to_apply.append
+        pop_staged_op = self._stash.popleft
+        unique_keys = set()
+
+        # nullify the ops that cancel against the most recent staged for a key
+        while self._stash:
+            op = pop_staged_op()
+            if self._items[op.key] and op.invert() == self._items[op.key][-1]:
+                self._items[op.key].pop()  # if the new op is the inverse of the last op, we can safely null both
+                continue
+            elif self._items[op.key] and self._items[op.key][-1] == op:  # duplicate of last op
+                continue  # raise an error?
+            else:
+                append_op_needed(op)
+                unique_keys.add(op.key)
+        for op in ops_to_apply:
+            if op.key in self._items and len(self._items[op.key]) and self._items[op.key][-1] == op.invert():
+                self._items[op.key].pop()
+                if not self._items[op.key]:
+                    self._items.pop(op.key)
+                continue
+            if not self._enforce_integrity:
+                self._items[op.key].append(op)
+                continue
+            stored_val = existing[op.key]
+            has_stored_val = stored_val is not None
+            delete_stored_op = None if not has_stored_val else RevertableDelete(op.key, stored_val)
+            will_delete_existing_stored = False if delete_stored_op is None else (delete_stored_op in self._items[op.key])
+            try:
+                if op.is_delete:
+                    if has_stored_val and stored_val != op.value and not will_delete_existing_stored:
+                        # there is a value and we're not deleting it in this op
+                        # check that a delete for the stored value is in the stack
+                        raise OpStackIntegrity(f"db op tries to delete with incorrect existing value {op}\nvs\n{stored_val}")
+                    elif not stored_val:
+                        raise OpStackIntegrity(f"db op tries to delete nonexistent key: {op}")
+                    elif stored_val != op.value:
+                        raise OpStackIntegrity(f"db op tries to delete with incorrect value: {op}")
+                else:
+                    if has_stored_val and not will_delete_existing_stored:
+                        raise OpStackIntegrity(f"db op tries to overwrite before deleting existing: {op}")
+                    if op.key in self._items and len(self._items[op.key]) and self._items[op.key][-1].is_put:
+                        raise OpStackIntegrity(f"db op tries to overwrite with {op} before deleting pending "
+                                               f"{self._items[op.key][-1]}")
+            except OpStackIntegrity as err:
+                if op.key[:1] in self._unsafe_prefixes:
+                    log.debug(f"skipping over integrity error: {err}")
+                else:
+                    raise err
+            self._items[op.key].append(op)
+
+        self._stashed_last_op_for_key.clear()
 
     def append_op(self, op: RevertableOp):
         """
@@ -217,15 +284,10 @@ class RevertableOpStack:
                     raise err
             self._items[op.key].append(op)
 
-    def extend_ops(self, ops: Iterable[RevertableOp]):
-        """
-        Apply a sequence of put or delete ops, checking that they introduce no integrity errors
-        """
-        for op in ops:
-            self.append_op(op)
-
     def clear(self):
         self._items.clear()
+        self._stash.clear()
+        self._stashed_last_op_for_key.clear()
 
     def __len__(self):
         return sum(map(len, self._items.values()))
@@ -254,6 +316,8 @@ class RevertableOpStack:
             op, packed = RevertableOp.unpack(packed)
             self.append_op(op)
 
-    def get_last_op_for_key(self, key: bytes) -> Optional[RevertableOp]:
+    def get_pending_op(self, key: bytes) -> Optional[RevertableOp]:
+        if key in self._stashed_last_op_for_key:
+            return self._stashed_last_op_for_key[key]
         if key in self._items and self._items[key]:
             return self._items[key][-1]

--- a/hub/elastic_sync/service.py
+++ b/hub/elastic_sync/service.py
@@ -89,7 +89,10 @@ class ElasticSyncService(BlockchainReaderService):
         info = {}
         if os.path.exists(self._es_info_path):
             with open(self._es_info_path, 'r') as f:
-                info.update(json.loads(f.read()))
+                try:
+                    info.update(json.loads(f.read()))
+                except json.decoder.JSONDecodeError:
+                    self.log.warning('failed to parse es sync status file')
         self._last_wrote_height = int(info.get('height', 0))
         self._last_wrote_block_hash = info.get('block_hash', None)
 

--- a/hub/elastic_sync/service.py
+++ b/hub/elastic_sync/service.py
@@ -250,7 +250,7 @@ class ElasticSyncService(BlockchainReaderService):
                                                                                     apply_blocking=False,
                                                                                     apply_filtering=False):
                 if not claim:
-                    self.log.warning("wat")
+                    self.log.warning("cannot sync claim %s", (claim_hash or b'').hex())
                     continue
                 claims[claim_hash] = claim
                 total_extras[claim_hash] = claim

--- a/hub/scribe/db.py
+++ b/hub/scribe/db.py
@@ -13,9 +13,10 @@ class PrimaryDB(SecondaryDB):
                  cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,
                  max_open_files: int = 64, blocking_channel_ids: List[str] = None,
                  filtering_channel_ids: List[str] = None, executor: ThreadPoolExecutor = None,
-                 index_address_status=False):
+                 index_address_status=False, enforce_integrity=True):
         super().__init__(coin, db_dir, '', max_open_files, reorg_limit, cache_all_claim_txos, cache_all_tx_hashes,
-                         blocking_channel_ids, filtering_channel_ids, executor, index_address_status)
+                         blocking_channel_ids, filtering_channel_ids, executor, index_address_status,
+                         enforce_integrity=enforce_integrity)
 
     def _rebuild_hashX_status_index(self, start_height: int):
         self.logger.warning("rebuilding the address status index...")

--- a/hub/scribe/env.py
+++ b/hub/scribe/env.py
@@ -7,7 +7,8 @@ class BlockchainEnv(Env):
                  blocking_channel_ids=None, filtering_channel_ids=None,
                  db_max_open_files=64, daemon_url=None, hashX_history_cache_size=None,
                  index_address_status=None, rebuild_address_status_from_height=None,
-                 daemon_ca_path=None, history_tx_cache_size=None):
+                 daemon_ca_path=None, history_tx_cache_size=None,
+                 db_disable_integrity_checks=False):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
                          cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.db_max_open_files = db_max_open_files
@@ -19,6 +20,7 @@ class BlockchainEnv(Env):
         self.daemon_ca_path = daemon_ca_path if daemon_ca_path else None
         self.history_tx_cache_size = history_tx_cache_size if history_tx_cache_size is not None else \
             self.integer('HISTORY_TX_CACHE_SIZE', 4194304)
+        self.db_disable_integrity_checks = db_disable_integrity_checks
 
     @classmethod
     def contribute_to_arg_parser(cls, parser):
@@ -30,6 +32,9 @@ class BlockchainEnv(Env):
                             default=env_daemon_url)
         parser.add_argument('--daemon_ca_path', type=str, default='',
                             help='Path to the lbcd ca file, used for lbcd with ssl')
+        parser.add_argument('--db_disable_integrity_checks', action='store_true',
+                            help="Disable verifications that no db operation breaks the ability to be rewound",
+                            default=False)
         parser.add_argument('--db_max_open_files', type=int, default=64,
                             help='This setting translates into the max_open_files option given to rocksdb. '
                                  'A higher number will use more memory. Defaults to 64.')
@@ -55,5 +60,6 @@ class BlockchainEnv(Env):
             cache_all_claim_txos=args.cache_all_claim_txos, index_address_status=args.index_address_statuses,
             hashX_history_cache_size=args.address_history_cache_size,
             rebuild_address_status_from_height=args.rebuild_address_status_from_height,
-            daemon_ca_path=args.daemon_ca_path, history_tx_cache_size=args.history_tx_cache_size
+            daemon_ca_path=args.daemon_ca_path, history_tx_cache_size=args.history_tx_cache_size,
+            db_disable_integrity_checks=args.db_disable_integrity_checks
         )

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -231,7 +231,7 @@ class BlockchainProcessorService(BlockchainService):
                     )
                     txs_added = self.tx_count - start_count
                     msg = f"advanced to {self.height:<5.0f} (took {(time.perf_counter() - start):0.3f}s) | +{txs_added:<4.0f} txs (total txs: {self.tx_count:<9.0f}) | {txi_count:->4.0f}/{txo_count:+>4.0f} utxos | {c_spent:->4.0f}/{c_added:+>4.0f} claims | {s_spent:->4.0f}/{s_added:+>4.0f} supports | abandoned: {abandoned:<4.0f} / {abandoned_chan:>4.0f}"
-                    self.log.warning(msg)
+                    self.log.info(msg)
                     if self.height == self.coin.nExtendedClaimExpirationForkHeight:
                         self.log.warning(
                             "applying extended claim expiration fork on claims accepted by, %i", self.height

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -2145,6 +2145,9 @@ class BlockchainProcessorService(BlockchainService):
             elif self.db.db_version == 10:
                 from hub.db.migrators.migrate10to11 import migrate, FROM_VERSION, TO_VERSION
                 self.db._index_address_status = self.env.index_address_status
+            elif self.db.db_version == 11:
+                from hub.db.migrators.migrate11to12 import migrate, FROM_VERSION, TO_VERSION
+                self.db._index_address_status = self.env.index_address_status
             else:
                 raise RuntimeError("unknown db version")
             self.log.warning(f"migrating database from version {FROM_VERSION} to version {TO_VERSION}")

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -1092,7 +1092,7 @@ class BlockchainProcessorService(BlockchainService):
                     self.activated_support_amount_by_claim[activated.claim_hash].append(amount)
                     self.active_support_amount_delta[activated.claim_hash] += amount
                 self.effective_amount_delta[activated.claim_hash] += amount
-                activated_added_to_effective_amount.add(activated.claim_hash)
+                activated_added_to_effective_amount.add((activated_txo.tx_num, activated_txo.position))
                 self.activation_by_claim_by_name[activated.normalized_name][activated.claim_hash].append((activated_txo, amount))
                 # print(f"\tactivate {'support' if txo_type == ACTIVATED_SUPPORT_TXO_TYPE else 'claim'} "
                 #       f"{activated.claim_hash.hex()} @ {activated_txo.height}")
@@ -1324,7 +1324,7 @@ class BlockchainProcessorService(BlockchainService):
                                     ACTIVATED_CLAIM_TXO_TYPE, winning_claim_hash, tx_num,
                                     position, height, name, amount
                                 )
-                                if winning_claim_hash not in activated_added_to_effective_amount:
+                                if (tx_num, position) not in activated_added_to_effective_amount:
                                     self.effective_amount_delta[winning_claim_hash] += amount
                         self.taken_over_names.add(name)
                         if controlling:

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -1057,8 +1057,6 @@ class BlockchainProcessorService(BlockchainService):
         # add the activation/delayed-activation ops
         for activated, activated_txos in activated_at_height.items():
             controlling = get_controlling(activated.normalized_name)
-            if activated.claim_hash in self.abandoned_claims:
-                continue
             reactivate = False
             if not controlling or controlling.claim_hash == activated.claim_hash:
                 # there is no delay for claims to a name without a controlling value or to the controlling value

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -138,7 +138,8 @@ class BlockchainProcessorService(BlockchainService):
             env.coin, env.db_dir, env.reorg_limit, cache_all_claim_txos=env.cache_all_claim_txos,
             cache_all_tx_hashes=env.cache_all_tx_hashes, max_open_files=env.db_max_open_files,
             blocking_channel_ids=env.blocking_channel_ids, filtering_channel_ids=env.filtering_channel_ids,
-            executor=self._executor, index_address_status=env.index_address_status
+            executor=self._executor, index_address_status=env.index_address_status,
+            enforce_integrity=not env.db_disable_integrity_checks
         )
 
     async def run_in_thread_with_lock(self, func, *args):

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -1322,10 +1322,10 @@ class BlockchainProcessorService(BlockchainService):
                                 self.effective_amount_delta[winning_claim_hash] += amount
                     self.taken_over_names.add(name)
                     if controlling:
-                        self.db.prefix_db.claim_takeover.stage_delete(
+                        self.db.prefix_db.claim_takeover.stash_delete(
                             (name,), (controlling.claim_hash, controlling.height)
                         )
-                    self.db.prefix_db.claim_takeover.stage_put((name,), (winning_claim_hash, height))
+                    self.db.prefix_db.claim_takeover.stash_put((name,), (winning_claim_hash, height))
                     if controlling and controlling.claim_hash not in self.abandoned_claims:
                         self.touched_claim_hashes.add(controlling.claim_hash)
                     self.touched_claim_hashes.add(winning_claim_hash)

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -1314,6 +1314,14 @@ class BlockchainProcessorService(BlockchainService):
                                     ACTIVATED_CLAIM_TXO_TYPE, winning_claim_hash, tx_num,
                                     position, previous_pending_activate.height, name, amount
                                 )
+                            pending_activated = self.db.prefix_db.activated.get_pending(
+                                ACTIVATED_CLAIM_TXO_TYPE, tx_num, position
+                            )
+                            if pending_activated:
+                                self.get_remove_activate_ops(
+                                    ACTIVATED_CLAIM_TXO_TYPE, winning_claim_hash, tx_num, position,
+                                    pending_activated.height, name, amount
+                                )
                             self.get_activate_ops(
                                 ACTIVATED_CLAIM_TXO_TYPE, winning_claim_hash, tx_num,
                                 position, height, name, amount

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -230,11 +230,8 @@ class BlockchainProcessorService(BlockchainService):
                         self.advance_block, block
                     )
                     txs_added = self.tx_count - start_count
-                    self.log.info(
-                        "advanced to %i, %i(+%i) txs, -%i/+%i utxos, -%i/+%i claims (%i/%i abandoned), -%i/+%i supports in %0.3fs", self.height,
-                        self.tx_count, txs_added, txi_count, txo_count, c_spent, c_added, abandoned, abandoned_chan, s_spent, s_added,
-                        time.perf_counter() - start
-                    )
+                    msg = f"advanced to {self.height:<5.0f} (took {(time.perf_counter() - start):0.3f}s) | +{txs_added:<4.0f} txs (total txs: {self.tx_count:<9.0f}) | {txi_count:->4.0f}/{txo_count:+>4.0f} utxos | {c_spent:->4.0f}/{c_added:+>4.0f} claims | {s_spent:->4.0f}/{s_added:+>4.0f} supports | abandoned: {abandoned:<4.0f} / {abandoned_chan:>4.0f}"
+                    self.log.warning(msg)
                     if self.height == self.coin.nExtendedClaimExpirationForkHeight:
                         self.log.warning(
                             "applying extended claim expiration fork on claims accepted by, %i", self.height

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -505,11 +505,14 @@ class BlockchainProcessorService(BlockchainService):
         self.future_effective_amount_delta[supported_claim_hash] += txo.value
 
     def _add_claim_or_support(self, height: int, tx_hash: bytes, tx_num: int, nout: int, txo: 'TxOutput',
-                              spent_claims: typing.Dict[bytes, Tuple[int, int, str]], first_input: 'TxInput'):
+                              spent_claims: typing.Dict[bytes, Tuple[int, int, str]], first_input: 'TxInput') -> int:
         if txo.is_claim or txo.is_update:
             self._add_claim_or_update(height, txo, tx_hash, tx_num, nout, spent_claims, first_input)
+            return 1
         elif txo.is_support:
             self._add_support(height, txo, tx_num, nout)
+            return 2
+        return 0
 
     def _spend_claims_and_supports(self, txis: List[TxInput], spent_claims: Dict[bytes, Tuple[int, int, str]]):
         tx_nums = self.db.get_tx_nums(

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -2018,11 +2018,11 @@ class BlockchainProcessorService(BlockchainService):
         }
         for (tx_hash, nout), (hashX, amount, txin_num) in txo_hashXs.items():
             if not hashX:
-                hashX_value = hashX_utxos.get((tx_hash[:4], txin_num, nout))
+                hashX_value = hashX_utxos.get((tx_hash, nout))
                 if not hashX_value:
                     continue
                 hashX = hashX_value.hashX
-                utxo_value = utxos.get((hashX, txin_num, nout))
+                utxo_value = utxos.get((tx_hash, nout))
                 if not utxo_value:
                     self.log.warning(
                         "%s:%s is not found in UTXO db for %s", hash_to_hex_str(tx_hash), nout, hash_to_hex_str(hashX)

--- a/hub/scribe/transaction/__init__.py
+++ b/hub/scribe/transaction/__init__.py
@@ -1,6 +1,7 @@
 import sys
 import functools
 import typing
+import time
 from dataclasses import dataclass
 from struct import Struct
 from hub.schema.claim import Claim
@@ -192,3 +193,21 @@ class Block(typing.NamedTuple):
     raw: bytes
     header: bytes
     transactions: typing.List[Tx]
+
+    @property
+    def decoded_header(self):
+        header = self.header
+        version = int.from_bytes(header[:4], byteorder='little')
+        ts = time.gmtime(int.from_bytes(header[100:104], byteorder='little'))
+        timestamp = f"{ts.tm_year}-{ts.tm_mon}-{ts.tm_mday}"
+        bits = int.from_bytes(header[104:108], byteorder='little')
+        nonce = int.from_bytes(header[108:112], byteorder='little')
+        return {
+            'version': version,
+            'prev_block_hash': header[4:36][::-1].hex(),
+            'merkle_root': header[36:68][::-1].hex(),
+            'claim_trie_root': header[68:100][::-1].hex(),
+            'timestamp': timestamp,
+            'bits': bits,
+            'nonce': nonce
+        }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -8,16 +8,8 @@ SNAPSHOT_URL="${SNAPSHOT_URL:-}" #off by default. latest snapshot at https://lbr
 
 if [[ "$HUB_COMMAND" == "scribe" ]] && [[ -n "$SNAPSHOT_URL" ]] && [[ ! -d /database/lbry-rocksdb ]]; then
   files="$(ls)"
-  echo "Downloading hub snapshot from $SNAPSHOT_URL"
-  wget --no-verbose --trust-server-names --content-disposition "$SNAPSHOT_URL"
-  echo "Extracting snapshot..."
-  filename="$(grep -vf <(echo "$files") <(ls))" # finds the file that was not there before
-  case "$filename" in
-    *.tgz|*.tar.gz|*.tar.bz2 )  tar xvf "$filename" --directory /database ;;
-    *.zip ) unzip "$filename" -d /database/ ;;
-    * ) echo "Don't know how to extract ${filename}. SNAPSHOT COULD NOT BE LOADED" && exit 1 ;;
-  esac
-  rm "$filename"
+  echo "Downloading and extracting hub snapshot from $SNAPSHOT_URL"
+  wget --no-verbose -c "$SNAPSHOT_URL" -O - | tar x -C /database
 fi
 
 if [ -z "$HUB_COMMAND" ]; then

--- a/tests/test_resolve_command.py
+++ b/tests/test_resolve_command.py
@@ -1463,27 +1463,27 @@ class ResolveClaimTakeovers(BaseResolveTestCase):
         COIN = int(1E8)
 
         self.assertEqual(self.conductor.spv_node.writer.height, 207)
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (208, bytes.fromhex(claim_id1)), (0, 10 * COIN)
         )
         await self.generate(1)
         self.assertEqual(self.conductor.spv_node.writer.height, 208)
 
         self.assertEqual(1.7090807854206793, await get_trending_score(claim_id1))
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (209, bytes.fromhex(claim_id1)), (10 * COIN, 100 * COIN)
         )
         await self.generate(1)
         self.assertEqual(self.conductor.spv_node.writer.height, 209)
         self.assertEqual(2.2437974397778886, await get_trending_score(claim_id1))
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (309, bytes.fromhex(claim_id1)), (100 * COIN, 1000000 * COIN)
         )
         await self.generate(100)
         self.assertEqual(self.conductor.spv_node.writer.height, 309)
         self.assertEqual(5.157053472135866, await get_trending_score(claim_id1))
 
-        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stage_put(
+        self.conductor.spv_node.writer.db.prefix_db.trending_notification.stash_put(
             (409, bytes.fromhex(claim_id1)), (1000000 * COIN, 1 * COIN)
         )
 

--- a/tests/test_revertable.py
+++ b/tests/test_revertable.py
@@ -125,24 +125,24 @@ class TestRevertablePrefixDB(unittest.TestCase):
         takeover_height = 10000000
 
         self.assertIsNone(self.db.claim_takeover.get(name))
-        self.db.claim_takeover.stage_put((name,), (claim_hash1, takeover_height))
+        self.db.claim_takeover.stash_put((name,), (claim_hash1, takeover_height))
         self.assertIsNone(self.db.claim_takeover.get(name))
         self.assertEqual(10000000, self.db.claim_takeover.get_pending(name).height)
 
         self.db.commit(10000000, b'\x00' * 32)
         self.assertEqual(10000000, self.db.claim_takeover.get(name).height)
 
-        self.db.claim_takeover.stage_delete((name,), (claim_hash1, takeover_height))
-        self.db.claim_takeover.stage_put((name,), (claim_hash2, takeover_height + 1))
-        self.db.claim_takeover.stage_delete((name,), (claim_hash2, takeover_height + 1))
+        self.db.claim_takeover.stash_delete((name,), (claim_hash1, takeover_height))
+        self.db.claim_takeover.stash_put((name,), (claim_hash2, takeover_height + 1))
+        self.db.claim_takeover.stash_delete((name,), (claim_hash2, takeover_height + 1))
         self.db.commit(10000001, b'\x01' * 32)
         self.assertIsNone(self.db.claim_takeover.get(name))
-        self.db.claim_takeover.stage_put((name,), (claim_hash3, takeover_height + 2))
+        self.db.claim_takeover.stash_put((name,), (claim_hash3, takeover_height + 2))
         self.db.commit(10000002, b'\x02' * 32)
         self.assertEqual(10000002, self.db.claim_takeover.get(name).height)
 
-        self.db.claim_takeover.stage_delete((name,), (claim_hash3, takeover_height + 2))
-        self.db.claim_takeover.stage_put((name,), (claim_hash2, takeover_height + 3))
+        self.db.claim_takeover.stash_delete((name,), (claim_hash3, takeover_height + 2))
+        self.db.claim_takeover.stash_put((name,), (claim_hash2, takeover_height + 3))
         self.db.commit(10000003, b'\x03' * 32)
         self.assertEqual(10000003, self.db.claim_takeover.get(name).height)
 
@@ -162,15 +162,15 @@ class TestRevertablePrefixDB(unittest.TestCase):
         claim_hash2 = 20 * b'\x02'
         claim_hash3 = 20 * b'\x03'
         overflow_value = 0xffffffff
-        self.db.claim_expiration.stage_put((99, 999, 0), (claim_hash0, name))
-        self.db.claim_expiration.stage_put((100, 1000, 0), (claim_hash1, name))
-        self.db.claim_expiration.stage_put((100, 1001, 0), (claim_hash2, name))
-        self.db.claim_expiration.stage_put((101, 1002, 0), (claim_hash3, name))
-        self.db.claim_expiration.stage_put((overflow_value - 1, 1003, 0), (claim_hash3, name))
-        self.db.claim_expiration.stage_put((overflow_value, 1004, 0), (claim_hash3, name))
-        self.db.tx_num.stage_put((b'\x00' * 32,), (101,))
-        self.db.claim_takeover.stage_put((name,), (claim_hash3, 101))
-        self.db.db_state.stage_put((), (b'n?\xcf\x12\x99\xd4\xec]y\xc3\xa4\xc9\x1dbJJ\xcf\x9e.\x17=\x95\xa1\xa0POgvihuV', 0, 1, b'VuhivgOP\xa0\xa1\x95=\x17.\x9e\xcfJJb\x1d\xc9\xa4\xc3y]\xec\xd4\x99\x12\xcf?n', 1, 0, 1, 7, 1, -1, -1, 0, 0, 0))
+        self.db.claim_expiration.stash_put((99, 999, 0), (claim_hash0, name))
+        self.db.claim_expiration.stash_put((100, 1000, 0), (claim_hash1, name))
+        self.db.claim_expiration.stash_put((100, 1001, 0), (claim_hash2, name))
+        self.db.claim_expiration.stash_put((101, 1002, 0), (claim_hash3, name))
+        self.db.claim_expiration.stash_put((overflow_value - 1, 1003, 0), (claim_hash3, name))
+        self.db.claim_expiration.stash_put((overflow_value, 1004, 0), (claim_hash3, name))
+        self.db.tx_num.stash_put((b'\x00' * 32,), (101,))
+        self.db.claim_takeover.stash_put((name,), (claim_hash3, 101))
+        self.db.db_state.stash_put((), (b'n?\xcf\x12\x99\xd4\xec]y\xc3\xa4\xc9\x1dbJJ\xcf\x9e.\x17=\x95\xa1\xa0POgvihuV', 0, 1, b'VuhivgOP\xa0\xa1\x95=\x17.\x9e\xcfJJb\x1d\xc9\xa4\xc3y]\xec\xd4\x99\x12\xcf?n', 1, 0, 1, 7, 1, -1, -1, 0, 0, 0))
         self.db.unsafe_commit()
 
         state = self.db.db_state.get()
@@ -217,9 +217,9 @@ class TestRevertablePrefixDB(unittest.TestCase):
         tx_num = 101
         for x in range(255):
             claim_hash = 20 * chr(x).encode()
-            self.db.active_amount.stage_put((claim_hash, 1, 200, tx_num, 1), (100000,))
-            self.db.active_amount.stage_put((claim_hash, 1, 201, tx_num + 1, 1), (200000,))
-            self.db.active_amount.stage_put((claim_hash, 1, 202, tx_num + 2, 1), (300000,))
+            self.db.active_amount.stash_put((claim_hash, 1, 200, tx_num, 1), (100000,))
+            self.db.active_amount.stash_put((claim_hash, 1, 201, tx_num + 1, 1), (200000,))
+            self.db.active_amount.stash_put((claim_hash, 1, 202, tx_num + 2, 1), (300000,))
             tx_num += 3
         self.db.unsafe_commit()
 


### PR DESCRIPTION
This branch significantly improves scribe sync time and scaling by doing the following:
  - Previously, RevertableOps would be verified (they they don't delete something that doesn't exist or put onto an existing value unexpectedly) as they were staged, this meant lots of single `get` lookups against the db, potentially redundantly if a key is touched multiple times. Now they are accumulated on a per-transaction basis before being verified in bulk using the `multi_get` api, which can be improved upon further.
  - Adds `FutureEffectiveAmountPrefixRow` column family to the db to eliminate needing to do an intensive `iterate` scan for one of the values needed to calculate takeovers.
  - Fully switches scribe to using batched lookups on `EffectiveAmountPrefixRow` and `FutureEffectiveAmountPrefixRow` for internal pending effective amount calculations instead of having looped `iterate` scans.

 
Bug fixes:
  - Fixes a number of takeover / activation related edge case bugs that had not previously surfaced due to not having test coverage and them not causing integrity errors, upon adding the effective amounts indexes these bugs would cause them to underflow (go negative) where it should not be possible.
- Fixes https://github.com/lbryio/hub/issues/97
- Fixes https://github.com/lbryio/hub/issues/104


Deprecated:
 - Drops `--elastic_host`, `--elastic_port`, `--elastic_notifier_host`, `--elastic_notifier_port` arguments to `herald`

New features:
 - [Adds failover functionality for elasticsearch and elastic sync notifiers to herald](https://github.com/lbryio/hub/issues/74) using a simplified argument `--elastic_services`, which is comma separated and defaults to `--elastic_services=127.0.0.1:9200/127.0.0.1:19080`.
  - Adds an optional `--db_disable_integrity_checks` flag to `scribe` to make initial sync much faster.
