### PR TITLE
Add IPv6 support to StatusServer and related classes.

### DIFF
--- a/hub/common.py
+++ b/hub/common.py
@@ -5,6 +5,7 @@ import hmac
 import ipaddress
 import logging
 import logging.handlers
+import socket
 import typing
 import collections
 from bisect import insort_right
@@ -151,6 +152,38 @@ def protocol_version(client_req, min_tuple, max_tuple):
         result = None
 
     return result, client_min
+
+
+async def resolve_host(url: str, port: int, proto: str,
+                       family: int = socket.AF_INET, all_results: bool = False) \
+        -> typing.Union[str, typing.List[str]]:
+    if proto not in ['udp', 'tcp']:
+        raise Exception("invalid protocol")
+    try:
+        if ipaddress.ip_address(url):
+            return [url] if all_results else url
+    except ValueError:
+        pass
+    loop = asyncio.get_running_loop()
+    records = await loop.getaddrinfo(
+        url, port,
+        proto=socket.IPPROTO_TCP if proto == 'tcp' else socket.IPPROTO_UDP,
+        type=socket.SOCK_STREAM if proto == 'tcp' else socket.SOCK_DGRAM,
+        family=family,
+    )
+    def addr_not_ipv4_mapped(rec):
+        _, _, _, _, sockaddr = rec
+        ipaddr = ipaddress.ip_address(sockaddr[0])
+        return ipaddr.version != 6 or not ipaddr.ipv4_mapped
+    records = filter(addr_not_ipv4_mapped, records)
+    results = [sockaddr[0] for fam, type, prot, canonname, sockaddr in records]
+    if not results and not all_results:
+        raise socket.gaierror(
+            socket.EAI_ADDRFAMILY,
+            'The specified network host does not have any network '
+            'addresses in the requested address family'
+        )
+    return results if all_results else results[0]
 
 
 class LRUCacheWithMetrics:
@@ -577,10 +610,10 @@ IPV4_TO_6_RELAY_SUBNET = ipaddress.ip_network('192.88.99.0/24')
 def is_valid_public_ipv4(address, allow_localhost: bool = False, allow_lan: bool = False):
     try:
         parsed_ip = ipaddress.ip_address(address)
-        if parsed_ip.is_loopback and allow_localhost:
-            return True
-        if allow_lan and parsed_ip.is_private:
-            return True
+        if parsed_ip.is_loopback:
+            return allow_localhost
+        if parsed_ip.is_private:
+            return allow_lan
         if any((parsed_ip.version != 4, parsed_ip.is_unspecified, parsed_ip.is_link_local, parsed_ip.is_loopback,
                 parsed_ip.is_multicast, parsed_ip.is_reserved, parsed_ip.is_private)):
             return False
@@ -593,12 +626,14 @@ def is_valid_public_ipv4(address, allow_localhost: bool = False, allow_lan: bool
 def is_valid_public_ipv6(address, allow_localhost: bool = False, allow_lan: bool = False):
     try:
         parsed_ip = ipaddress.ip_address(address)
-        if parsed_ip.is_loopback and allow_localhost:
-            return True
-        if allow_lan and parsed_ip.is_private:
-            return True
-        return not any((parsed_ip.version != 6, parsed_ip.is_unspecified, parsed_ip.is_link_local, parsed_ip.is_loopback,
-                        parsed_ip.is_multicast, parsed_ip.is_reserved, parsed_ip.is_private))
+        if parsed_ip.is_loopback:
+            return allow_localhost
+        if parsed_ip.is_private:
+            return allow_lan
+        return not any((parsed_ip.version != 6, parsed_ip.is_unspecified,
+                        parsed_ip.is_link_local, parsed_ip.is_loopback,
+                        parsed_ip.is_multicast, parsed_ip.is_reserved,
+                        parsed_ip.is_private, parsed_ip.ipv4_mapped))
     except (ipaddress.AddressValueError, ValueError):
         return False
 

--- a/hub/common.py
+++ b/hub/common.py
@@ -610,11 +610,13 @@ IPV4_TO_6_RELAY_SUBNET = ipaddress.ip_network('192.88.99.0/24')
 def is_valid_public_ipv4(address, allow_localhost: bool = False, allow_lan: bool = False):
     try:
         parsed_ip = ipaddress.ip_address(address)
+        if parsed_ip.version != 4:
+            return False
         if parsed_ip.is_loopback:
             return allow_localhost
         if parsed_ip.is_private:
             return allow_lan
-        if any((parsed_ip.version != 4, parsed_ip.is_unspecified, parsed_ip.is_link_local, parsed_ip.is_loopback,
+        if any((parsed_ip.is_unspecified, parsed_ip.is_link_local, parsed_ip.is_loopback,
                 parsed_ip.is_multicast, parsed_ip.is_reserved, parsed_ip.is_private)):
             return False
         else:
@@ -626,14 +628,15 @@ def is_valid_public_ipv4(address, allow_localhost: bool = False, allow_lan: bool
 def is_valid_public_ipv6(address, allow_localhost: bool = False, allow_lan: bool = False):
     try:
         parsed_ip = ipaddress.ip_address(address)
+        if parsed_ip.version != 6:
+            return False
         if parsed_ip.is_loopback:
             return allow_localhost
         if parsed_ip.is_private:
             return allow_lan
-        return not any((parsed_ip.version != 6, parsed_ip.is_unspecified,
-                        parsed_ip.is_link_local, parsed_ip.is_loopback,
-                        parsed_ip.is_multicast, parsed_ip.is_reserved,
-                        parsed_ip.is_private, parsed_ip.ipv4_mapped))
+        return not any((parsed_ip.is_unspecified, parsed_ip.is_link_local, parsed_ip.is_loopback,
+                        parsed_ip.is_multicast, parsed_ip.is_reserved, parsed_ip.is_private,
+                        parsed_ip.ipv4_mapped))
     except (ipaddress.AddressValueError, ValueError):
         return False
 

--- a/hub/common.py
+++ b/hub/common.py
@@ -590,6 +590,20 @@ def is_valid_public_ipv4(address, allow_localhost: bool = False, allow_lan: bool
     except (ipaddress.AddressValueError, ValueError):
         return False
 
+def is_valid_public_ipv6(address, allow_localhost: bool = False, allow_lan: bool = False):
+    try:
+        parsed_ip = ipaddress.ip_address(address)
+        if parsed_ip.is_loopback and allow_localhost:
+            return True
+        if allow_lan and parsed_ip.is_private:
+            return True
+        return not any((parsed_ip.version != 6, parsed_ip.is_unspecified, parsed_ip.is_link_local, parsed_ip.is_loopback,
+                        parsed_ip.is_multicast, parsed_ip.is_reserved, parsed_ip.is_private))
+    except (ipaddress.AddressValueError, ValueError):
+        return False
+
+def is_valid_public_ip(address, **kwargs):
+    return is_valid_public_ipv6(address, **kwargs) or is_valid_public_ipv4(address, **kwargs)
 
 def sha256(x):
     """Simple wrapper of hashlib sha256."""

--- a/hub/env.py
+++ b/hub/env.py
@@ -117,10 +117,6 @@ class Env:
         result = [part.strip() for part in host.split(',')]
         if len(result) == 1:
             result = result[0]
-        if result == 'localhost':
-            # 'localhost' resolves to ::1 (ipv6) on many systems, which fails on default setup of
-            # docker, using 127.0.0.1 instead forces ipv4
-            result = '127.0.0.1'
         return result
 
     def sane_max_sessions(self):

--- a/hub/herald/session.py
+++ b/hub/herald/session.py
@@ -271,7 +271,8 @@ class SessionManager:
                                   f'{host}:{port:d} : {e!r}')
             raise
         else:
-            self.logger.info(f'{kind} server listening on {host}:{port:d}')
+            for s in self.servers[kind].sockets:
+                self.logger.info(f'{kind} server listening on {s.getsockname()[:2]}')
 
     async def _start_external_servers(self):
         """Start listening on TCP and SSL ports, but only if the respective

--- a/hub/herald/udp.py
+++ b/hub/herald/udp.py
@@ -275,6 +275,11 @@ class SPVStatusClientProtocol(asyncio.DatagramProtocol):
 
     def datagram_received(self, data: bytes, addr: Union[Tuple[str, int], Tuple[str, int, int, int]]):
         try:
+            if len(addr) > 2: # IPv6 with possible mapped IPv4
+                ipaddr = ipaddress.ip_address(addr[0])
+                if ipaddr.ipv4_mapped:
+                    # mapped IPv4 address identified
+                    addr = (ipaddr.ipv4_mapped.compressed, addr[1])
             self.responses.put_nowait(((addr[:2], perf_counter()), SPVPong.decode(data)))
         except (ValueError, struct.error, AttributeError, TypeError, RuntimeError):
             return

--- a/hub/herald/udp.py
+++ b/hub/herald/udp.py
@@ -244,8 +244,8 @@ class StatusServer:
         self._protocols.append(proto)
 
     async def stop(self):
-        for p in self._protocols:
-            await p.close()
+        for proto in self._protocols:
+            await proto.close()
         self._protocols.clear()
 
     @property
@@ -253,16 +253,16 @@ class StatusServer:
         return self._protocols
 
     def set_unavailable(self):
-        for p in self._protocols:
-            p.set_unavailable()
+        for proto in self._protocols:
+            proto.set_unavailable()
 
     def set_available(self):
-        for p in self._protocols:
-            p.set_available()
+        for proto in self._protocols:
+            proto.set_available()
 
     def set_height(self, height: int, tip: bytes):
-        for p in self._protocols:
-            p.set_height(height, tip)
+        for proto in self._protocols:
+            proto.set_height(height, tip)
 
 
 class SPVStatusClientProtocol(asyncio.DatagramProtocol):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'certifi>=2021.10.08',
         'colorama==0.3.7',
         'cffi==1.13.2',
-        'protobuf==3.18.3',
+        'protobuf==3.17.2',
         'msgpack==0.6.1',
         'prometheus_client==0.7.1',
         'coincurve==15.0.0',


### PR DESCRIPTION
Fixes #117
Update: Fixes #121

Not sure whether this is complete. I think I need help with this part in `hub/env.py`:

```
        if result == 'localhost':
            # 'localhost' resolves to ::1 (ipv6) on many systems, which fails on default setup of
            # docker, using 127.0.0.1 instead forces ipv4
            result = '127.0.0.1'
```

If I allow the `cs_host()` to be `localhost` instead of 127.0.0.1, then it will start TCP servers on both v4/v6 sockets.

What is the problem with docker and this behavior?
