### PR TITLE
Check for scribe needing to be restarted due to low memory

### DIFF
--- a/hub/elastic_sync/db.py
+++ b/hub/elastic_sync/db.py
@@ -9,11 +9,11 @@ from hub.db.common import ResolveResult
 
 class ElasticSyncDB(SecondaryDB):
     def __init__(self, coin, db_dir: str, secondary_name: str, max_open_files: int = -1, reorg_limit: int = 200,
-                 cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,
+                 cache_all_tx_hashes: bool = False,
                  blocking_channel_ids: List[str] = None,
                  filtering_channel_ids: List[str] = None, executor: ThreadPoolExecutor = None,
                  index_address_status=False):
-        super().__init__(coin, db_dir, secondary_name, max_open_files, reorg_limit, cache_all_claim_txos,
+        super().__init__(coin, db_dir, secondary_name, max_open_files, reorg_limit,
                          cache_all_tx_hashes, blocking_channel_ids, filtering_channel_ids, executor,
                          index_address_status)
         self.block_timestamp_cache = LRUCache(1024)

--- a/hub/elastic_sync/env.py
+++ b/hub/elastic_sync/env.py
@@ -3,11 +3,11 @@ from hub.env import Env
 
 class ElasticEnv(Env):
     def __init__(self, db_dir=None, max_query_workers=None, chain=None, reorg_limit=None, prometheus_port=None,
-                 cache_all_tx_hashes=None, cache_all_claim_txos=None, elastic_host=None, elastic_port=None,
+                 cache_all_tx_hashes=None, elastic_host=None, elastic_port=None,
                  es_index_prefix=None, elastic_notifier_host=None, elastic_notifier_port=None,
                  blocking_channel_ids=None, filtering_channel_ids=None, reindex=False):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
-                         cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids)
+                         blocking_channel_ids, filtering_channel_ids)
         self.elastic_host = elastic_host if elastic_host is not None else self.default('ELASTIC_HOST', 'localhost')
         self.elastic_port = elastic_port if elastic_port is not None else self.integer('ELASTIC_PORT', 9200)
         self.elastic_notifier_host = elastic_notifier_host if elastic_notifier_host is not None else self.default(
@@ -43,7 +43,7 @@ class ElasticEnv(Env):
             elastic_port=args.elastic_port, max_query_workers=args.max_query_workers, chain=args.chain,
             es_index_prefix=args.es_index_prefix, reorg_limit=args.reorg_limit,
             prometheus_port=args.prometheus_port, cache_all_tx_hashes=args.cache_all_tx_hashes,
-            cache_all_claim_txos=args.cache_all_claim_txos, blocking_channel_ids=args.blocking_channel_ids,
+            blocking_channel_ids=args.blocking_channel_ids,
             filtering_channel_ids=args.filtering_channel_ids, elastic_notifier_host=args.elastic_notifier_host,
             elastic_notifier_port=args.elastic_notifier_port
         )

--- a/hub/elastic_sync/service.py
+++ b/hub/elastic_sync/service.py
@@ -49,7 +49,7 @@ class ElasticSyncService(BlockchainReaderService):
     def open_db(self):
         env = self.env
         self.db = ElasticSyncDB(
-            env.coin, env.db_dir, self.secondary_name, -1, env.reorg_limit, env.cache_all_claim_txos,
+            env.coin, env.db_dir, self.secondary_name, -1, env.reorg_limit,
             env.cache_all_tx_hashes, blocking_channel_ids=env.blocking_channel_ids,
             filtering_channel_ids=env.filtering_channel_ids, executor=self._executor,
             index_address_status=env.index_address_status

--- a/hub/env.py
+++ b/hub/env.py
@@ -30,7 +30,7 @@ class Env:
         pass
 
     def __init__(self, db_dir=None, max_query_workers=None, chain=None, reorg_limit=None,
-                 prometheus_port=None, cache_all_tx_hashes=None, cache_all_claim_txos=None,
+                 prometheus_port=None, cache_all_tx_hashes=None,
                  blocking_channel_ids=None, filtering_channel_ids=None, index_address_status=None):
 
         self.logger = logging.getLogger(__name__)
@@ -46,7 +46,6 @@ class Env:
         self.reorg_limit = reorg_limit if reorg_limit is not None else self.integer('REORG_LIMIT', self.coin.REORG_LIMIT)
         self.prometheus_port = prometheus_port if prometheus_port is not None else self.integer('PROMETHEUS_PORT', 0)
         self.cache_all_tx_hashes = cache_all_tx_hashes if cache_all_tx_hashes is not None else self.boolean('CACHE_ALL_TX_HASHES', False)
-        self.cache_all_claim_txos = cache_all_claim_txos if cache_all_claim_txos is not None else self.boolean('CACHE_ALL_CLAIM_TXOS', False)
         # Filtering / Blocking
         self.blocking_channel_ids = blocking_channel_ids if blocking_channel_ids is not None else self.default(
             'BLOCKING_CHANNEL_IDS', '').split(' ')
@@ -171,11 +170,6 @@ class Env:
                                  "resolve, transaction fetching, and block sync all faster at the expense of higher "
                                  "memory usage (at least 10GB more). Can be set in env with 'CACHE_ALL_TX_HASHES'.",
                             default=cls.boolean('CACHE_ALL_TX_HASHES', False))
-        parser.add_argument('--cache_all_claim_txos', action='store_true',
-                            help="Load all claim txos into memory. This will make address subscriptions and sync, "
-                                 "resolve, transaction fetching, and block sync all faster at the expense of higher "
-                                 "memory usage. Can be set in env with 'CACHE_ALL_CLAIM_TXOS'.",
-                            default=cls.boolean('CACHE_ALL_CLAIM_TXOS', False))
         parser.add_argument('--prometheus_port', type=int, default=cls.integer('PROMETHEUS_PORT', 0),
                             help="Port for prometheus metrics to listen on, disabled by default. "
                                  "Can be set in env with 'PROMETHEUS_PORT'.")

--- a/hub/herald/db.py
+++ b/hub/herald/db.py
@@ -6,11 +6,11 @@ from hub.db import SecondaryDB
 
 class HeraldDB(SecondaryDB):
     def __init__(self, coin, db_dir: str, secondary_name: str, max_open_files: int = -1, reorg_limit: int = 200,
-                 cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,
+                 cache_all_tx_hashes: bool = False,
                  blocking_channel_ids: List[str] = None,
                  filtering_channel_ids: List[str] = None, executor: ThreadPoolExecutor = None,
                  index_address_status=False, merkle_cache_size=32768, tx_cache_size=32768):
-        super().__init__(coin, db_dir, secondary_name, max_open_files, reorg_limit, cache_all_claim_txos,
+        super().__init__(coin, db_dir, secondary_name, max_open_files, reorg_limit,
                          cache_all_tx_hashes, blocking_channel_ids, filtering_channel_ids, executor,
                          index_address_status, merkle_cache_size, tx_cache_size)
         # self.headers = None

--- a/hub/herald/env.py
+++ b/hub/herald/env.py
@@ -19,7 +19,7 @@ def parse_es_services(elastic_services_arg: str):
 
 class ServerEnv(Env):
     def __init__(self, db_dir=None, max_query_workers=None, chain=None, reorg_limit=None,
-                 prometheus_port=None, cache_all_tx_hashes=None, cache_all_claim_txos=None,
+                 prometheus_port=None, cache_all_tx_hashes=None,
                  daemon_url=None, host=None, elastic_services=None, es_index_prefix=None,
                  tcp_port=None, udp_port=None, banner_file=None, allow_lan_udp=None, country=None,
                  payment_address=None, donation_address=None, max_send=None, max_receive=None, max_sessions=None,
@@ -29,7 +29,7 @@ class ServerEnv(Env):
                  merkle_cache_size=None, resolved_url_cache_size=None, tx_cache_size=None,
                  history_tx_cache_size=None, largest_address_history_cache_size=None):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
-                         cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
+                         blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
         self.host = host if host is not None else self.default('HOST', 'localhost')
         self.elastic_services = deque(parse_es_services(elastic_services or 'localhost:9200/localhost:19080'))
@@ -153,7 +153,7 @@ class ServerEnv(Env):
             es_index_prefix=args.es_index_prefix, reorg_limit=args.reorg_limit, tcp_port=args.tcp_port,
             udp_port=args.udp_port, prometheus_port=args.prometheus_port, banner_file=args.banner_file,
             allow_lan_udp=args.allow_lan_udp, cache_all_tx_hashes=args.cache_all_tx_hashes,
-            cache_all_claim_txos=args.cache_all_claim_txos, country=args.country, payment_address=args.payment_address,
+            country=args.country, payment_address=args.payment_address,
             donation_address=args.donation_address, max_send=args.max_send, max_receive=args.max_receive,
             max_sessions=args.max_sessions, session_timeout=args.session_timeout,
             drop_client=args.drop_client, description=args.description, daily_fee=args.daily_fee,

--- a/hub/herald/service.py
+++ b/hub/herald/service.py
@@ -53,7 +53,7 @@ class HubServerService(BlockchainReaderService):
     def open_db(self):
         env = self.env
         self.db = HeraldDB(
-            env.coin, env.db_dir, self.secondary_name, -1, env.reorg_limit, env.cache_all_claim_txos,
+            env.coin, env.db_dir, self.secondary_name, -1, env.reorg_limit,
             env.cache_all_tx_hashes, blocking_channel_ids=env.blocking_channel_ids,
             filtering_channel_ids=env.filtering_channel_ids, executor=self._executor,
             index_address_status=env.index_address_status, merkle_cache_size=env.merkle_cache_size,

--- a/hub/scribe/db.py
+++ b/hub/scribe/db.py
@@ -11,11 +11,11 @@ from hub.db import SecondaryDB
 
 class PrimaryDB(SecondaryDB):
     def __init__(self, coin, db_dir: str, reorg_limit: int = 200,
-                 cache_all_claim_txos: bool = False, cache_all_tx_hashes: bool = False,
+                 cache_all_tx_hashes: bool = False,
                  max_open_files: int = 64, blocking_channel_ids: List[str] = None,
                  filtering_channel_ids: List[str] = None, executor: ThreadPoolExecutor = None,
                  index_address_status=False, enforce_integrity=True):
-        super().__init__(coin, db_dir, '', max_open_files, reorg_limit, cache_all_claim_txos, cache_all_tx_hashes,
+        super().__init__(coin, db_dir, '', max_open_files, reorg_limit, cache_all_tx_hashes,
                          blocking_channel_ids, filtering_channel_ids, executor, index_address_status,
                          enforce_integrity=enforce_integrity)
 

--- a/hub/scribe/env.py
+++ b/hub/scribe/env.py
@@ -3,14 +3,13 @@ from hub.env import Env
 
 class BlockchainEnv(Env):
     def __init__(self, db_dir=None, max_query_workers=None, chain=None, reorg_limit=None,
-                 prometheus_port=None, cache_all_tx_hashes=None, cache_all_claim_txos=None,
-                 blocking_channel_ids=None, filtering_channel_ids=None,
+                 prometheus_port=None, cache_all_tx_hashes=None, blocking_channel_ids=None, filtering_channel_ids=None,
                  db_max_open_files=64, daemon_url=None, hashX_history_cache_size=None,
                  index_address_status=None, rebuild_address_status_from_height=None,
                  daemon_ca_path=None, history_tx_cache_size=None,
                  db_disable_integrity_checks=False):
         super().__init__(db_dir, max_query_workers, chain, reorg_limit, prometheus_port, cache_all_tx_hashes,
-                         cache_all_claim_txos, blocking_channel_ids, filtering_channel_ids, index_address_status)
+                         blocking_channel_ids, filtering_channel_ids, index_address_status)
         self.db_max_open_files = db_max_open_files
         self.daemon_url = daemon_url if daemon_url is not None else self.required('DAEMON_URL')
         self.hashX_history_cache_size = hashX_history_cache_size if hashX_history_cache_size is not None \
@@ -57,7 +56,7 @@ class BlockchainEnv(Env):
             db_dir=args.db_dir, daemon_url=args.daemon_url, db_max_open_files=args.db_max_open_files,
             max_query_workers=args.max_query_workers, chain=args.chain, reorg_limit=args.reorg_limit,
             prometheus_port=args.prometheus_port, cache_all_tx_hashes=args.cache_all_tx_hashes,
-            cache_all_claim_txos=args.cache_all_claim_txos, index_address_status=args.index_address_statuses,
+            index_address_status=args.index_address_statuses,
             hashX_history_cache_size=args.address_history_cache_size,
             rebuild_address_status_from_height=args.rebuild_address_status_from_height,
             daemon_ca_path=args.daemon_ca_path, history_tx_cache_size=args.history_tx_cache_size,

--- a/hub/scribe/service.py
+++ b/hub/scribe/service.py
@@ -1,3 +1,4 @@
+import os
 import time
 import asyncio
 import typing
@@ -2069,6 +2070,8 @@ class BlockchainProcessorService(BlockchainService):
         """Loop forever processing blocks as they arrive."""
         self._caught_up_event = caught_up_event
         try:
+            if os.path.exists(self.db._need_restart_path):
+                raise MemoryError()
             if self.height != self.daemon.cached_height() and not self.db.catching_up:
                 await self._need_catch_up()  # tell the readers that we're still catching up with lbrycrd/lbcd
             while not self._stopping:

--- a/hub/service.py
+++ b/hub/service.py
@@ -37,7 +37,7 @@ class BlockchainService:
     def open_db(self):
         env = self.env
         self.db = SecondaryDB(
-            env.coin, env.db_dir, self.secondary_name, -1, env.reorg_limit, env.cache_all_claim_txos,
+            env.coin, env.db_dir, self.secondary_name, -1, env.reorg_limit,
             env.cache_all_tx_hashes, blocking_channel_ids=env.blocking_channel_ids,
             filtering_channel_ids=env.filtering_channel_ids, executor=self._executor,
             index_address_status=env.index_address_status


### PR DESCRIPTION
This updates scribe to check for a canary file being created when herald or es-sync fail to open the db and to shut down in order to be restarted. 

When the primary db hasn't done a compaction flush it can cause the secondary dbs to require much more memory to open than normal until the primary is cycled. When memory is low this can cause herald/es-sync to get stuck in a restart loop until scribe is restarted.